### PR TITLE
Change JSON Schema lib

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,11 +1,12 @@
 [versions]
 jackson = "2.16.1"
 retrofit = "2.9.0"
+victoolsJsonSchema = "4.38.0"
+javaxValidation = "2.0.1.Final"
 
 [libraries]
 jacksonDatabind = { module = "com.fasterxml.jackson.core:jackson-databind", version.ref = "jackson" }
 jacksonAnnotations = { module = "com.fasterxml.jackson.core:jackson-annotations", version.ref = "jackson" }
-jacksonJsonSchema = { module = "com.kjetland:mbknor-jackson-jsonschema_2.12", version = "1.0.34" }
 lombok = { module = "org.projectlombok:lombok", version = "1.18.30" }
 junitBom = { module = "org.junit:junit-bom", version = "5.8.2" }
 retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit" }
@@ -13,3 +14,6 @@ retrofitJackson = { module = "com.squareup.retrofit2:converter-jackson", version
 retrofitRxJava2 = { module = "com.squareup.retrofit2:adapter-rxjava2", version.ref = "retrofit" }
 retrofitMock = { module = "com.squareup.retrofit2:retrofit-mock", version.ref = "retrofit" }
 jtokkit = { module = "com.knuddels:jtokkit", version = "1.1.0" }
+victoolsJsonSchemaGenerator = { module = "com.github.victools:jsonschema-generator", version.ref = "victoolsJsonSchema" }
+victoolsJsonSchemaJackson = { module = "com.github.victools:jsonschema-module-jackson", version.ref = "victoolsJsonSchema" }
+javaxValidationApi = { module = "javax.validation:validation-api", version.ref = "javaxValidation" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -6,7 +6,9 @@ dependencies {
     api libs.retrofit
     implementation libs.retrofitRxJava2
     implementation libs.retrofitJackson
-    implementation libs.jacksonJsonSchema
+    implementation libs.victoolsJsonSchemaGenerator
+    implementation libs.victoolsJsonSchemaJackson
+    implementation libs.javaxValidationApi
 
     testImplementation(platform(libs.junitBom))
     testImplementation 'org.junit.jupiter:junit-jupiter'

--- a/service/src/main/java/com/launchableinc/openai/service/ChatFunctionParametersSerializer.java
+++ b/service/src/main/java/com/launchableinc/openai/service/ChatFunctionParametersSerializer.java
@@ -3,18 +3,22 @@ package com.launchableinc.openai.service;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializerProvider;
-import com.kjetland.jackson.jsonSchema.JsonSchemaConfig;
-import com.kjetland.jackson.jsonSchema.JsonSchemaGenerator;
+import com.github.victools.jsonschema.generator.SchemaGenerator;
+import com.github.victools.jsonschema.generator.SchemaGeneratorConfigBuilder;
+import com.github.victools.jsonschema.generator.SchemaVersion;
+import com.github.victools.jsonschema.module.jackson.JacksonModule;
+import com.github.victools.jsonschema.module.jackson.JacksonOption;
 
 import java.io.IOException;
 
 public class ChatFunctionParametersSerializer extends JsonSerializer<Class<?>> {
 
-	private final ObjectMapper mapper = new ObjectMapper();
-	private final JsonSchemaConfig config = JsonSchemaConfig.vanillaJsonSchemaDraft4();
-	private final JsonSchemaGenerator jsonSchemaGenerator = new JsonSchemaGenerator(mapper, config);
+	private final SchemaGenerator schemaGenerator = new SchemaGenerator(
+			new SchemaGeneratorConfigBuilder(SchemaVersion.DRAFT_7)
+					.with(new JacksonModule(JacksonOption.RESPECT_JSONPROPERTY_REQUIRED))
+					.build()
+	);
 
 	@Override
 	public void serialize(Class<?> value, JsonGenerator gen, SerializerProvider serializers)
@@ -23,7 +27,7 @@ public class ChatFunctionParametersSerializer extends JsonSerializer<Class<?>> {
 			gen.writeNull();
 		} else {
 			try {
-				JsonNode schema = jsonSchemaGenerator.generateJsonSchema(value);
+				JsonNode schema = schemaGenerator.generateSchema(value);
 				gen.writeObject(schema);
 			} catch (Exception e) {
 				throw new RuntimeException("Failed to generate JSON Schema", e);


### PR DESCRIPTION
  This PR removes the Scala dependency from the project by replacing mbknor-jackson-jsonschema_2.12 with victools/jsonschema-generator, a modern, actively maintained JSON Schema
  generator.

  Background

  Old Library ([mbknor-jackson-jsonschema](https://github.com/mbknor/mbknor-jackson-jsonSchema)):
  - Last meaningful activity: 2020 (4+ years ago)
  - Status: No longer maintained by original author, migrated to HubSpot fork
  - Scala dependency: Required Scala 2.12 runtime
  - JSON Schema version: Draft 4 (2013 specification)

  New Library ([victools/jsonschema-generator](https://github.com/victools/jsonschema-generator)):
  - Latest release: v4.38.0 (March 24, 2025)
  - Activity: Actively maintained with regular releases and community engagement
  - Language: Pure Java (no Scala dependency)
  - JSON Schema version: Draft 7 compliance

  OpenAI API Compatibility

  The new implementation uses JSON Schema Draft 7, which is officially supported by OpenAI:
  - Evidence: OpenAI's official Node.js SDK (openai-node) explicitly uses Draft 7 in their
  https://github.com/openai/openai-node/blob/1a3850112451e81840840c960bf6925753d4fac3/src/lib/jsonschema.ts#L52
  - Recommended schema: http://json-schema.org/draft-07/schema#